### PR TITLE
Update water rendering, optimize 2D rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,11 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@ant-design/css-animation": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@ant-design/css-animation/-/css-animation-1.7.2.tgz",
-      "integrity": "sha512-bvVOe7A+r7lws58B7r+fgnQDK90cV45AXuvGx6i5CCSX1W/M3AJnHsNggDANBxEtWdNdFWcDd5LorB+RdSIlBw=="
-    },
     "@babel/code-frame": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
@@ -2592,25 +2587,6 @@
       "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==",
       "dev": true
     },
-    "@types/rc-slider": {
-      "version": "8.6.6",
-      "resolved": "https://registry.npmjs.org/@types/rc-slider/-/rc-slider-8.6.6.tgz",
-      "integrity": "sha512-2Q3vwKrSm3PbgiMNwzxMkOaMtcAGi0xQ8WPeVKoabk1vNYHiVR44DMC3mr9jC2lhbxCBgGBJWF9sBhmnSDQ8Bg==",
-      "dev": true,
-      "requires": {
-        "@types/rc-tooltip": "*",
-        "@types/react": "*"
-      }
-    },
-    "@types/rc-tooltip": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/@types/rc-tooltip/-/rc-tooltip-3.7.3.tgz",
-      "integrity": "sha512-2+lEqXGGY6MSoE/SGEdSf75B1TGljQXBdeaDfBNhXASytMU/p/1XeftZgphERZrjT4Afsh25nH/7tFlTmpdOxQ==",
-      "dev": true,
-      "requires": {
-        "@types/react": "*"
-      }
-    },
     "@types/react": {
       "version": "16.9.41",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.41.tgz",
@@ -4585,11 +4561,6 @@
         }
       }
     },
-    "classnames": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
-    },
     "clean-css": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
@@ -5782,11 +5753,6 @@
       "requires": {
         "esutils": "^2.0.2"
       }
-    },
-    "dom-align": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/dom-align/-/dom-align-1.12.0.tgz",
-      "integrity": "sha512-YkoezQuhp3SLFGdOlr5xkqZ640iXrnHAwVYcDg8ZKRUtO7mSzSC2BA5V0VuyAwPSJA4CLIc6EDDJh4bEsD2+zA=="
     },
     "dom-converter": {
       "version": "0.2.0",
@@ -13085,7 +13051,8 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
     },
     "picomatch": {
       "version": "2.2.2",
@@ -13627,6 +13594,7 @@
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
       "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "dev": true,
       "requires": {
         "performance-now": "^2.1.0"
       }
@@ -13699,74 +13667,13 @@
       }
     },
     "raw-loader": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-0.5.1.tgz",
-      "integrity": "sha1-DD0L6u2KAclm2Xh793goElKpeao=",
-      "dev": true
-    },
-    "rc-align": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-4.0.1.tgz",
-      "integrity": "sha512-RQ5Fhxl0LW+zsxbY8dxAcpXdaHkHH2jzRSSpvBTS7G9LMK3T+WRcn4ovjg/eqAESM6TdTx0hfqWF2S1pO75jxQ==",
+      "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-4.0.1.tgz",
+      "integrity": "sha512-baolhQBSi3iNh1cglJjA0mYzga+wePk7vdEX//1dTFd+v4TsQlQE0jitJSNF1OIP82rdYulH7otaVmdlDaJ64A==",
+      "dev": true,
       "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "2.x",
-        "dom-align": "^1.7.0",
-        "rc-util": "^5.0.1",
-        "resize-observer-polyfill": "^1.5.1"
-      }
-    },
-    "rc-animate": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/rc-animate/-/rc-animate-3.1.0.tgz",
-      "integrity": "sha512-8FsM+3B1H+0AyTyGggY6JyVldHTs1CyYT8CfTmG/nGHHXlecvSLeICJhcKgRLjUiQlctNnRtB1rwz79cvBVmrw==",
-      "requires": {
-        "@ant-design/css-animation": "^1.7.2",
-        "classnames": "^2.2.6",
-        "raf": "^3.4.0",
-        "rc-util": "^5.0.1"
-      }
-    },
-    "rc-slider": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-9.3.1.tgz",
-      "integrity": "sha512-c52PWPyrfJWh28K6dixAm0906L3/4MUIxqrNQA4TLnC/Z+cBNycWJUZoJerpwSOE1HdM3XDwixCsmtFc/7aWlQ==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.5",
-        "rc-tooltip": "^4.0.0",
-        "rc-util": "^5.0.0",
-        "shallowequal": "^1.1.0"
-      }
-    },
-    "rc-tooltip": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-4.2.1.tgz",
-      "integrity": "sha512-oykuaGsHg7RFvPUaxUpxo7ScEqtH61C66x4JUmjlFlSS8gSx2L8JFtfwM1D68SLBxUqGqJObtxj4TED75gQTiA==",
-      "requires": {
-        "rc-trigger": "^4.2.1"
-      }
-    },
-    "rc-trigger": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-4.3.0.tgz",
-      "integrity": "sha512-jnGNzosXmDdivMBjPCYe/AfOXTpJU2/xQ9XukgoXDQEoZq/9lcI1r7eUIfq70WlWpLxlUEqQktiV3hwyy6Nw9g==",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.6",
-        "raf": "^3.4.1",
-        "rc-align": "^4.0.0",
-        "rc-animate": "^3.0.0",
-        "rc-util": "^5.0.1"
-      }
-    },
-    "rc-util": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.0.4.tgz",
-      "integrity": "sha512-cd19RCrE0DJH6UcJ9+V3eaXA/5sNWyVKOKkWl8ZM2OqgNzVb8fv0obf/TkuvSN43tmTsgqY8k7OqpFYHhmef8g==",
-      "requires": {
-        "react-is": "^16.12.0",
-        "shallowequal": "^1.1.0"
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^2.6.5"
       }
     },
     "react": {
@@ -14765,6 +14672,14 @@
       "dev": true,
       "requires": {
         "raw-loader": "~0.5.1"
+      },
+      "dependencies": {
+        "raw-loader": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-0.5.1.tgz",
+          "integrity": "sha1-DD0L6u2KAclm2Xh793goElKpeao=",
+          "dev": true
+        }
       }
     },
     "scss-tokenizer": {
@@ -15011,11 +14926,6 @@
           "dev": true
         }
       }
-    },
-    "shallowequal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "shebang-command": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "node-sass": "^4.14.1",
     "npm-run-all": "^4.1.5",
     "postcss-loader": "^3.0.0",
+    "raw-loader": "^4.0.1",
     "rimraf": "^3.0.2",
     "sass-loader": "^8.0.2",
     "script-loader": "^0.7.2",

--- a/src/components/view-3d/terrain.tsx
+++ b/src/components/view-3d/terrain.tsx
@@ -48,8 +48,10 @@ export const Terrain = observer(function WrappedComponent() {
   const height = planeHeight(simulation);
 
   const geometryRef = useUpdate<THREE.PlaneBufferGeometry>(geometry => {
-    setupElevation(geometry, simulation);
-  }, [simulation.cellsBaseElevationFlag]);
+    if (simulation.config.view3d) {
+      setupElevation(geometry, simulation);
+    }
+  }, [simulation.config.view3d, simulation.cellsBaseElevationFlag]);
 
   const interactions: InteractionHandler[] = [
     useShowCoordsInteraction()
@@ -73,9 +75,9 @@ export const Terrain = observer(function WrappedComponent() {
         args={[PLANE_WIDTH, height, simulation.gridWidth - 1, simulation.gridHeight - 1]}
       />
       {
-        texture ?
-          <meshLambertMaterial attach="material" map={texture} /> :
-          <meshLambertMaterial attach="material" />
+        simulation.config.view3d ?
+          <meshStandardMaterial attach="material" map={texture || null} color="#aaa" /> :
+          <meshBasicMaterial attach="material" map={texture || null} /> // this material doesn't require any light
       }
     </mesh>
   );

--- a/src/components/view-3d/view-3d.tsx
+++ b/src/components/view-3d/view-3d.tsx
@@ -32,8 +32,13 @@ export const View3d = () => {
   return (
     <Canvas camera={{ fov: 33, up: DEFAULT_UP, position: cameraPos }} pixelRatio={pixelRatio} >
         <CameraControls/>
-        <hemisphereLight args={[0xC6C2B6, 0x3A403B, 1.2]} up={DEFAULT_UP} intensity={1.0}/>
-        <pointLight position={[0.5, 0.5, 3]} intensity={0.3}/>
+        {
+          simulation.config.view3d &&
+          <>
+            <hemisphereLight args={[0xC6C2B6, 0x3A403B, 1.2]} up={DEFAULT_UP} intensity={1.0}/>
+            <pointLight position={[0.5, 0.5, 3]} intensity={0.3}/>
+          </>
+        }
         <Terrain />
         <Water />
         <ShutterbugSupport/>

--- a/src/components/view-3d/water-fragment.glsl
+++ b/src/components/view-3d/water-fragment.glsl
@@ -1,0 +1,5 @@
+varying vec4 vColor;
+
+void main() {
+	gl_FragColor = vColor;
+}

--- a/src/components/view-3d/water-vertex.glsl
+++ b/src/components/view-3d/water-vertex.glsl
@@ -1,0 +1,8 @@
+uniform vec3 color;
+attribute float alpha;
+varying vec4 vColor;
+
+void main() {
+	vColor = vec4(color, alpha);
+	gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+}

--- a/src/components/view-3d/water.tsx
+++ b/src/components/view-3d/water.tsx
@@ -1,4 +1,4 @@
-import React  from "react";
+import React from "react";
 import { Cell } from "../../models/cell";
 import * as THREE from "three";
 import { BufferAttribute } from "three";
@@ -7,10 +7,18 @@ import { mToViewUnit, PLANE_WIDTH, planeHeight } from "./helpers";
 import { observer } from "mobx-react-lite";
 import { useStores } from "../../use-stores";
 import { useUpdate } from "react-three-fiber";
+// Very simple shaders. They won't work great in 3D view, as there's no lightning there. But 3D view is used only
+// for tests models at the moment. If 3D view ever gets more useful, these shaders should be updated to include
+// some light calculations / reflections.
+import waterVertexShader from "./water-vertex.glsl";
+import waterFragmentShader from "./water-fragment.glsl";
 
 const vertexIdx = (cell: Cell, gridWidth: number, gridHeight: number) => (gridHeight - 1 - cell.y) * gridWidth + cell.x;
 
-const MIN_WATER_DEPTH = 1e-4;
+const WATER_COL = new THREE.Vector3(80/255, 172/255, 255/255);
+const MAX_OPACITY = 0.75;
+// Water below this depth will have opacity between MAX_OPACITY and 0. It ensures that water appears and disappears smoothly.
+const MAX_OPACITY_WATER_DEPTH = 0.5; // m
 
 const setupElevation = (geometry: THREE.PlaneBufferGeometry, simulation: SimulationModel) => {
   const posArray = geometry.attributes.position.array as number[];
@@ -19,12 +27,19 @@ const setupElevation = (geometry: THREE.PlaneBufferGeometry, simulation: Simulat
   for (const cell of simulation.cells) {
     const zAttrIdx = vertexIdx(cell, simulation.gridWidth, simulation.gridHeight) * 3 + 2;
     // .baseElevation doesn't include water depth.
-    posArray[zAttrIdx] = cell.waterDepth > MIN_WATER_DEPTH ? cell.elevation * mult : -1e-4;
+    posArray[zAttrIdx] = cell.elevation * mult;
   }
-  // This is needed only in 3D view for realistic shading. When view is locked to 2D, it should be disabled,
-  // as it's pretty expensive (around 25ms for 300x300 grid on MBP 15" 2017).
   geometry.computeVertexNormals();
   (geometry.attributes.position as BufferAttribute).needsUpdate = true;
+};
+
+const setupAlpha = (geometry: THREE.PlaneBufferGeometry, simulation: SimulationModel) => {
+  const alphaArray = geometry.attributes.alpha.array as number[];
+  for (const cell of simulation.cells) {
+    const vertIdx = vertexIdx(cell, simulation.gridWidth, simulation.gridHeight);
+    alphaArray[vertIdx] = cell.waterDepth > MAX_OPACITY_WATER_DEPTH ? MAX_OPACITY : (cell.waterDepth / MAX_OPACITY_WATER_DEPTH) * MAX_OPACITY;
+  }
+  (geometry.attributes.alpha as BufferAttribute).needsUpdate = true;
 };
 
 export const Water = observer(function WrappedComponent() {
@@ -32,24 +47,43 @@ export const Water = observer(function WrappedComponent() {
   const height = planeHeight(simulation);
 
   const geometryRef = useUpdate<THREE.PlaneBufferGeometry>(geometry => {
-    geometry.setAttribute("color",
-      new THREE.Float32BufferAttribute(new Array((simulation.gridWidth) * (simulation.gridHeight) * 4), 4)
+    geometry.setAttribute("alpha",
+      new THREE.Float32BufferAttribute(new Array((simulation.gridWidth) * (simulation.gridHeight)), 1)
     );
   }, [simulation.gridWidth, simulation.gridHeight]);
 
+  // Elevation update is only necessary in 3D view.
   useUpdate<THREE.PlaneBufferGeometry>(geometry => {
-    setupElevation(geometry, simulation);
+    if (simulation.config.view3d) {
+      setupElevation(geometry, simulation);
+    }
+  }, [simulation.config.view3d, simulation.cellsStateFlag], geometryRef);
+
+  useUpdate<THREE.PlaneBufferGeometry>(geometry => {
+    setupAlpha(geometry, simulation);
   }, [simulation.cellsStateFlag], geometryRef);
 
+  const uniforms = {
+    color: {value: WATER_COL}
+  };
+
   return (
-    <mesh position={[PLANE_WIDTH * 0.5, height * 0.5, 0]} >
+    // In 2D view per-vertex elevation is never set, so it's necessary to keep this plane a bit higher than terrain plane.
+    <mesh position={[PLANE_WIDTH * 0.5, height * 0.5, simulation.config.view3d ? 0 : 0.001 ]} >
       <planeBufferGeometry
         attach="geometry"
         ref={geometryRef}
         center-x={0} center-y={0}
         args={[PLANE_WIDTH, height, simulation.gridWidth - 1, simulation.gridHeight - 1]}
       />
-      <meshStandardMaterial attach="material" color={"#50acff"}/>
+      {/* Note that standard ThreeJS materials don't let us specify alpha per vertex. That's why it's necessary to use ShaderMaterial and custom shaders. */}
+      <shaderMaterial
+        attach="material"
+        vertexShader={waterVertexShader}
+        fragmentShader={waterFragmentShader}
+        uniforms={uniforms}
+        transparent={true}
+      />
     </mesh>
   );
 });

--- a/src/components/view-3d/water.tsx
+++ b/src/components/view-3d/water.tsx
@@ -7,7 +7,7 @@ import { mToViewUnit, PLANE_WIDTH, planeHeight } from "./helpers";
 import { observer } from "mobx-react-lite";
 import { useStores } from "../../use-stores";
 import { useUpdate } from "react-three-fiber";
-// Very simple shaders. They won't work great in 3D view, as there's no lightning there. But 3D view is used only
+// Very simple shaders. They won't work great in 3D view, as there's no lighting there. But 3D view is used only
 // for tests models at the moment. If 3D view ever gets more useful, these shaders should be updated to include
 // some light calculations / reflections.
 import waterVertexShader from "./water-vertex.glsl";

--- a/src/config.ts
+++ b/src/config.ts
@@ -50,6 +50,7 @@ export interface ISimulationConfig {
   // We're trying to make sure that 24 hours take around 8 seconds of real world time.
   // But this will greatly depend on performance of the user machine at this point and might require more work later.
   modelTimeToHours: number;
+  view3d: boolean;
 }
 
 export interface IUrlConfig extends ISimulationConfig {
@@ -81,7 +82,8 @@ export const getDefaultConfig: () => IUrlConfig = () => ({
   floodPermeabilityMult: 0.1,
   riverStageIncreaseSpeed: 0.125,
   rainStrength: [0.0025, 0.005, 0.0075, 0.02],
-  modelTimeToHours: 0.066
+  modelTimeToHours: 0.066,
+  view3d: false
 });
 
 const getURLParam = (name: string) => {

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,6 +1,7 @@
 // So we can import CSS modules.
 declare module "*.sass";
 declare module "*.scss";
+declare module "*.glsl";
 declare module "*.svg" {
   const content: any;
   export default content;
@@ -10,3 +11,4 @@ declare module "*.png" {
   export = value;
 }
 declare module "shutterbug";
+

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -43,7 +43,8 @@ const presets: {[key: string]: Partial<ISimulationConfig>} = {
     minElevation: 0, // m
     maxElevation: 250, // m
     modelHeight: 10, // m
-    modelWidth: 10 // m
+    modelWidth: 10, // m
+    view3d: true
   },
   waterfall: {
     elevation: "data/waterfall_elevation.png",
@@ -52,7 +53,8 @@ const presets: {[key: string]: Partial<ISimulationConfig>} = {
     minElevation: 0, // m
     maxElevation: 30, // m
     modelHeight: 100, // m
-    modelWidth: 100 // m
+    modelWidth: 100, // m
+    view3d: true
   }
 };
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -77,7 +77,12 @@ module.exports = (env, argv) => {
               loader: '@svgr/webpack'
             }
           ]
-        }
+        },
+        {
+          // GLSL shaders should be loaded as strings.
+          test: /\.(glsl|txt)$/,
+          loader: 'raw-loader'
+        },
       ]
     },
     resolve: {


### PR DESCRIPTION
Demo (when it gets deployed):
http://flood.concord.org/branch/water-rendering/index.html

Water is semi-transparent by default (0.75 value provided by Micheal / Trudi), but also when it's below 0.5m, the opacity will be adjusted. It makes transitions much smoother.

Note that I had to use GLSL shaders as ThreeJS standard materials don't let us control alpha per vertex in an efficient way. They only let us specify alphaMap texture, but generating the whole texture won't be the best approach here.

I considered using 2D canvas or some other library, but I think it's still worth using WebGL. This simulation is a perfect candidate to be moved to GPU and in this case, we'll have all the data already there. 

I've also added some optimizations for 2D view - e.g. disabled lighting there (and used materials that don't require it), disabled elevation updates, etc.