### PR TITLE
Reimplement riverStage

### DIFF
--- a/src/components/bottom-bar.tsx
+++ b/src/components/bottom-bar.tsx
@@ -81,9 +81,6 @@ export const BottomBar: React.FC = observer(function WrappedComponent() {
         playing={simulation.simulationRunning}
         startStopDisabled={!simulation.ready}
       />
-      <BottomBarWidgetGroup title="River Stage">
-        { simulation.initialRiverStage.toFixed(2) } (0 low, 1 flood)
-      </BottomBarWidgetGroup>
     </BottomBarContainer>
   );
 });

--- a/src/components/bottom-bar.tsx
+++ b/src/components/bottom-bar.tsx
@@ -31,7 +31,7 @@ export const BottomBar: React.FC = observer(function WrappedComponent() {
   };
 
   const handleStartingWaterLevel = (event: ChangeEvent, value: number) => {
-    simulation.setInitialWaterLevel(value);
+    simulation.setInitialRiverStage(value);
   };
 
   const handleIncreaseRainDuration = () => {
@@ -41,7 +41,6 @@ export const BottomBar: React.FC = observer(function WrappedComponent() {
   const handleDecreaseRainDuration = () => {
     simulation.setRainDurationInDays(simulation.rainDurationInDays - 1);
   };
-
 
   return (
     <BottomBarContainer>
@@ -66,7 +65,7 @@ export const BottomBar: React.FC = observer(function WrappedComponent() {
       </BottomBarWidgetGroup>
       <BottomBarWidgetGroup title={["Starting", "Water Level"]} hoverable={true} className={css.startingWaterLevel}>
         <Slider
-          value={simulation.initialWaterLevel}
+          value={simulation.initialRiverStage}
           min={RiverStage.Low}
           max={RiverStage.High}
           step={null} // restrict values to marks values
@@ -83,7 +82,7 @@ export const BottomBar: React.FC = observer(function WrappedComponent() {
         startStopDisabled={!simulation.ready}
       />
       <BottomBarWidgetGroup title="River Stage">
-        { simulation.riverStage.toFixed(2) } (0 low, 1 flood)
+        { simulation.initialRiverStage.toFixed(2) } (0 low, 1 flood)
       </BottomBarWidgetGroup>
     </BottomBarContainer>
   );

--- a/src/components/gauge-reading-graph.tsx
+++ b/src/components/gauge-reading-graph.tsx
@@ -18,7 +18,7 @@ export const GaugeReadingGraph: React.FC<IProps> = observer(({ gauge }) => {
       <div className={css.graph}>
         {/* .slice() as it seems ChartJS doesn't work well with MobX observable arrays. There's an error about
           maximum call stack exceeded. MobX observable array differs a bit from regular Array instance. */}
-        <Graph points={gaugeReadingDataset.points[gauge - 1].slice()} yLabel="River Stage (feet)" maxY={30}/>
+        <Graph points={gaugeReadingDataset.points[gauge].slice()} yLabel="River Stage (feet)" maxY={30}/>
       </div>
     </div>
   );

--- a/src/components/side-container.tsx
+++ b/src/components/side-container.tsx
@@ -60,7 +60,7 @@ export const SideContainer = observer(() => {
           const Icon = GaugeMarker[idx];
           return (<TabPanel key={idx} className={`react-tabs__tab-panel ${css.tabPanel} ${gaugeBorderColorCss[idx]}`}>
               <Header><Icon className={css.icon}/> Steam Gauge {idx + 1}: Cross-section</Header>
-              <GaugeTab gauge={idx + 1}/>
+              <GaugeTab gauge={idx}/>
             </TabPanel>
           );
         }

--- a/src/config.ts
+++ b/src/config.ts
@@ -57,8 +57,9 @@ export interface ISimulationConfig {
 }
 
 export interface IGaugeConfig {
-  minDepth: number;
-  maxDepth: number;
+  minRiverDepth: number;
+  maxRiverDepth: number;
+  maxFloodDepth: number;
   x: number;
   y: number;
 }

--- a/src/models/cell.ts
+++ b/src/models/cell.ts
@@ -15,8 +15,10 @@ export class Cell {
   public isRiver = false;
   public baseElevation = 0;
   public permeability = 0;
+  public riverStage = 0;
   public waterDepth = 0;
   public initialWaterDepth = 0;
+  public initialRiverStage = 0;
   public fluxL = 0; // left
   public fluxR = 0; // right
   public fluxT = 0; // top

--- a/src/models/engine/flooding-engine.test.ts
+++ b/src/models/engine/flooding-engine.test.ts
@@ -143,7 +143,7 @@ describe("FloodingEngine", () => {
   });
 
   describe("addWaterInRiver", () => {
-    it("should add water using riverWaterIncrment value", () => {
+    it("should add water using riverWaterIncrement value, first incrementing riverStage, then waterDepth", () => {
       const c1 = new Cell({ x: 0, y: 0, waterDepth: 0, isRiver: true });
       const c2 = new Cell({ x: 1, y: 0, waterDepth: 0, isRiver: false });
       const cells = [c1, c2];
@@ -153,11 +153,45 @@ describe("FloodingEngine", () => {
         cellSize: 1
       });
 
-      engine.riverWaterIncrement = 1;
-      engine.addWaterInRiver(2);
+      c1.initialRiverStage = 0.5;
+      c1.riverStage = 0.5;
 
-      expect(c1.waterDepth).toEqual(2);
+      engine.riverWaterIncrement = 1;
+      engine.addWaterInRiver(4);
+
+      expect(c1.riverStage).toEqual(1); // + 1 * 4 * 0.125
+      expect(c1.waterDepth).toEqual(0);
+      expect(c2.riverStage).toEqual(0);
       expect(c2.waterDepth).toEqual(0);
+
+      engine.addWaterInRiver(2);
+      expect(c1.riverStage).toEqual(1.25); // + 1 * 2 * 0.125
+      expect(c1.waterDepth).toEqual(0);
+      expect(c2.riverStage).toEqual(0);
+      expect(c2.waterDepth).toEqual(0);
+
+      // Now waterDepth should start increasing, as riverStage is already > 1.
+      engine.addWaterInRiver(2);
+      expect(c1.riverStage).toEqual(1.25);
+      expect(c1.waterDepth).toEqual(2); // + 1 * 2
+
+      // Start reverse process.
+      engine.riverWaterIncrement = -1;
+      engine.addWaterInRiver(1);
+      expect(c1.riverStage).toEqual(1.25);
+      expect(c1.waterDepth).toEqual(1); // - 1 * 1
+
+      engine.addWaterInRiver(1);
+      expect(c1.riverStage).toEqual(1); // riverStage should be reset to 1 when waterDepth reaches 0.
+      expect(c1.waterDepth).toEqual(0);
+
+      engine.addWaterInRiver(1);
+      expect(c1.riverStage).toEqual(0.875); // - 1 * 1 * 0.125
+      expect(c1.waterDepth).toEqual(0);
+
+      engine.addWaterInRiver(12);
+      expect(c1.riverStage).toEqual(0.7); // min riverStage is equal to initialRiverStage + 0.2
+      expect(c1.waterDepth).toEqual(0);
     });
   });
 

--- a/src/models/engine/flooding-engine.ts
+++ b/src/models/engine/flooding-engine.ts
@@ -82,7 +82,10 @@ export class FloodingEngine {
 
   public addWaterInRiver(dt: number) {
     for (const cell of this.riverCells) {
-      if (cell.riverStage < 1) {
+      // When river is still not overflowing (riverStage <= 1), only riverStage value gets updated during this step.
+      // When riverStage gets bigger than 1, waterDepth is incremented too, which will trigger the flooding
+      // calculations in other steps.
+      if (cell.riverStage <= 1) {
         const riverStageDiff = this.riverWaterIncrement * dt * this.riverStageIncreaseSpeed;
         cell.riverStage += this.riverWaterIncrement * dt * this.riverStageIncreaseSpeed;
         if (riverStageDiff < 0) {
@@ -92,7 +95,9 @@ export class FloodingEngine {
       } else {
         cell.waterDepth = Math.max(0, cell.waterDepth + this.riverWaterIncrement * dt);
         if (cell.waterDepth === 0) {
-          cell.riverStage = 0.999;
+          // If we're here, it means that river has flooded, but not it's back to normal state (riverWaterIncrement
+          // is negative). Start decreasing riverStage value when waterDepth reaches 0.
+          cell.riverStage = 1;
         }
       }
     }

--- a/src/models/simulation.test.ts
+++ b/src/models/simulation.test.ts
@@ -38,7 +38,7 @@ describe("SimulationModel", () => {
     expect(s.cells.filter(c => c.isEdge).length).toEqual(16);
 
     expect(s.cellsBaseElevationFlag).toBeGreaterThan(0);
-    expect(s.cellsStateFlag).toBeGreaterThan(1);
+    expect(s.cellsStateFlag).toBeGreaterThan(0);
 
     expect(s.ready).toEqual(true);
 
@@ -101,18 +101,18 @@ describe("SimulationModel", () => {
 
       jest.spyOn(s.cells[0], "reset");
       s.time = 123;
-      s.rainDurationInDays = 123;
-      s.rainIntensity = 123;
-      s.initialWaterLevel = 123;
+      s.setRainDurationInDays(4);
+      s.setRainIntensity(123);
+      s.setInitialRiverStage(123);
 
       s.restart();
       expect(s.simulationRunning).toEqual(false);
       expect(s.simulationStarted).toEqual(false);
       expect(s.cells[0].reset).toHaveBeenCalled();
       expect(s.time).toEqual(0);
-      expect(s.rainDurationInDays).toEqual(123);
+      expect(s.rainDurationInDays).toEqual(4);
       expect(s.rainIntensity).toEqual(123);
-      expect(s.initialWaterLevel).toEqual(123);
+      expect(s.initialRiverStage).toEqual(123);
     });
   });
 
@@ -126,9 +126,9 @@ describe("SimulationModel", () => {
 
       jest.spyOn(s.cells[0], "reset");
       s.time = 123;
-      s.rainDurationInDays = 123;
-      s.rainIntensity = 123;
-      s.initialWaterLevel = 123;
+      s.setRainDurationInDays(123);
+      s.setRainIntensity(123);
+      s.setInitialRiverStage(123);
 
       s.reload();
       expect(s.simulationRunning).toEqual(false);
@@ -137,7 +137,7 @@ describe("SimulationModel", () => {
       expect(s.time).toEqual(0);
       expect(s.rainDurationInDays).toEqual(2);
       expect(s.rainIntensity).toEqual(RainIntensity.Medium);
-      expect(s.initialWaterLevel).toEqual(0.5);
+      expect(s.initialRiverStage).toEqual(0.5);
     });
   });
 
@@ -178,13 +178,6 @@ describe("SimulationModel", () => {
       await s.dataReadyPromise;
 
       s.simulationRunning = true;
-      const oldRiverStage = s.riverStage;
-      s.rafCallback();
-      expect(s.riverStage).toBeGreaterThan(oldRiverStage);
-      expect(s.riverStage).toBeLessThan(1);
-      expect(s.engine?.riverWaterIncrement).toEqual(0);
-
-      (s as any)._riverStage = 1;
       s.rafCallback();
       expect(s.engine?.riverWaterIncrement).toBeGreaterThan(0);
     });

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -12,20 +12,23 @@ const presets: {[key: string]: Partial<ISimulationConfig>} = {
     modelWidth: 8000, // m
     gauges: [
       {
-        minDepth: 0.5, // m
-        maxDepth: 4,
+        minRiverDepth: 0.5, // m
+        maxRiverDepth: 4,
+        maxFloodDepth: 8,
         x: 0.623,
         y: 0.743
       },
       {
-        minDepth: 0.5, // m
-        maxDepth: 4,
+        minRiverDepth: 0.5, // m
+        maxRiverDepth: 4,
+        maxFloodDepth: 8,
         x: 0.153,
         y: 0.44
       },
       {
-        minDepth: 0.5, // m
-        maxDepth: 4,
+        minRiverDepth: 0.5, // m
+        maxRiverDepth: 4,
+        maxFloodDepth: 8,
         x: 0.603,
         y: 0.26
       }


### PR DESCRIPTION
This PR removes global `riverStage` and moves this property to each (river) cell. Global riverStage worked well for the initial phase, as flood starts everywhere at the same moment. But it didn't work well when the flood was ending, as in various places of the map/river, the flood was ending in different moments. So, we couldn't just reverse the process and globally start decreasing riverStage from 1 to its initial value. That's why now riverStage is kept by each cell separately. It lets us create following River Stage graphs for each gauge:
<img width="833" alt="Screenshot 2020-08-19 at 23 49 38" src="https://user-images.githubusercontent.com/767857/90755340-516c7900-e2db-11ea-95ce-2bd74ee20105.png">
<img width="688" alt="Screenshot 2020-08-19 at 23 46 08" src="https://user-images.githubusercontent.com/767857/90755334-4fa2b580-e2db-11ea-9956-6764cdc543bb.png">
