### PR TITLE
Bug fixes, new URL param

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12014,14 +12014,14 @@
       }
     },
     "mobx": {
-      "version": "5.15.5",
-      "resolved": "https://registry.npmjs.org/mobx/-/mobx-5.15.5.tgz",
-      "integrity": "sha512-hzk17T+/IIYLPWClRcfoA6Q5aZhFpDCr1oh8RZzu+esWP77IX/lS0V/Ee1Np+aOPKFfbSInF0reHH0L/aFfSrw=="
+      "version": "5.15.6",
+      "resolved": "https://registry.npmjs.org/mobx/-/mobx-5.15.6.tgz",
+      "integrity": "sha512-U5nnx3UNdRkUjntpwzO060VWifGVx/JZeu/aMw4y28dTjDNjoY3vNKs6tFNm7z1qIfcPInsd9L9HIm8H0zTDqg=="
     },
     "mobx-react-lite": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-2.0.7.tgz",
-      "integrity": "sha512-YKAh2gThC6WooPnVZCoC+rV1bODAKFwkhxikzgH18wpBjkgTkkR9Sb0IesQAH5QrAEH/JQVmy47jcpQkf2Au3Q=="
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-2.2.2.tgz",
+      "integrity": "sha512-2SlXALHIkyUPDsV4VTKVR9DW7K3Ksh1aaIv3NrNJygTbhXe2A9GrcKHZ2ovIiOp/BXilOcTYemfHHZubP431dg=="
     },
     "moment": {
       "version": "2.26.0",
@@ -13779,9 +13779,9 @@
       }
     },
     "react-three-fiber": {
-      "version": "4.2.20",
-      "resolved": "https://registry.npmjs.org/react-three-fiber/-/react-three-fiber-4.2.20.tgz",
-      "integrity": "sha512-M5TCdGNKvofe37VMXnhbabgRDiRm9rnfxOmMFuLa+H9FiiLT3wUMMgE9eBmLh3McKgYXURETWKkNDePeQ0J0JQ==",
+      "version": "4.2.21",
+      "resolved": "https://registry.npmjs.org/react-three-fiber/-/react-three-fiber-4.2.21.tgz",
+      "integrity": "sha512-lbopEkL36cbAaG/y+iEGT1EFbVaVZBrOe2XGt2+HxsCL8AeWWiQQERo1HYiiqFc4p6DuoNq1hhOSxr1TKQjXuQ==",
       "requires": {
         "@babel/runtime": "^7.9.2",
         "@juggle/resize-observer": "^3.1.3",
@@ -16051,9 +16051,9 @@
       "dev": true
     },
     "three": {
-      "version": "0.120.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.120.0.tgz",
-      "integrity": "sha512-Swffpi3EAHWkmqC1MagKEzR5XgwkDiyeWI3M7vkGbBc0xhq2LcQmJj5DqBruLkrgcZQ+fM/+fSQBU1tDvggO4A=="
+      "version": "0.120.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.120.1.tgz",
+      "integrity": "sha512-ktaCRFUR7JUZcKec+cBRz+oBex5pOVaJhrtxvFF2T7on53o9UkEux+/Nh1g/4zeb4t/pbxIFcADbn/ACu3LC1g=="
     },
     "threejs-meshline": {
       "version": "2.0.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1067,6 +1067,16 @@
         "regenerator-runtime": "^0.13.4"
       }
     },
+    "@babel/runtime-corejs3": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz",
+      "integrity": "sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==",
+      "dev": true,
+      "requires": {
+        "core-js-pure": "^3.0.0",
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "@babel/template": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
@@ -2393,10 +2403,138 @@
         "loader-utils": "^2.0.0"
       }
     },
+    "@testing-library/dom": {
+      "version": "7.24.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.24.2.tgz",
+      "integrity": "sha512-ERxcZSoHx0EcN4HfshySEWmEf5Kkmgi+J7O79yCJ3xggzVlBJ2w/QjJUC+EBkJJ2OeSw48i3IoePN4w8JlVUIA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.10.3",
+        "@types/aria-query": "^4.2.0",
+        "aria-query": "^4.2.2",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.1",
+        "pretty-format": "^26.4.2"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+          "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/istanbul-reports": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-report": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+          "integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.3.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@testing-library/react": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.0.4.tgz",
+      "integrity": "sha512-U0fZO2zxm7M0CB5h1+lh31lbAwMSmDMEMGpMT3BUPJwIjDEKYWOV4dx7lb3x2Ue0Pyt77gmz/VropuJnSz/Iew==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.11.2",
+        "@testing-library/dom": "^7.24.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.11.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+          "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
     "@types/anymatch": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
       "integrity": "sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==",
+      "dev": true
+    },
+    "@types/aria-query": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.0.tgz",
+      "integrity": "sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A==",
       "dev": true
     },
     "@types/babel__core": {
@@ -3234,6 +3372,16 @@
       "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "aria-query": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+      "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.10.2",
+        "@babel/runtime-corejs3": "^7.10.2"
       }
     },
     "arr-diff": {
@@ -5075,6 +5223,12 @@
         }
       }
     },
+    "core-js-pure": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
+      "integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==",
+      "dev": true
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -5795,6 +5949,12 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "dom-accessibility-api": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.2.tgz",
+      "integrity": "sha512-k7hRNKAiPJXD2aBqfahSo4/01cTsKWXf+LqJgglnkN2Nz8TsxXKQBXHhKe0Ye9fEfHEZY49uSA5Sr3AqP/sWKA==",
+      "dev": true
     },
     "dom-converter": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     ],
     "moduleNameMapper": {
       "\\.svg$": "<rootDir>/__mocks__/svgMock.js",
-      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
+      "\\.(jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
       "\\.(css|less|sass|scss)$": "identity-obj-proxy"
     },
     "moduleFileExtensions": [
@@ -65,6 +65,7 @@
   "devDependencies": {
     "@cypress/webpack-preprocessor": "^5.4.1",
     "@svgr/webpack": "^5.4.0",
+    "@testing-library/react": "^11.0.4",
     "@types/chart.js": "^2.9.23",
     "@types/enzyme": "^3.10.5",
     "@types/enzyme-adapter-react-16": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -117,18 +117,18 @@
     "chart.js": "^2.9.3",
     "eventemitter3": "^4.0.4",
     "jquery": "^3.5.1",
-    "mobx": "^5.15.5",
-    "mobx-react-lite": "^2.0.7",
+    "mobx": "^5.15.6",
+    "mobx-react-lite": "^2.2.2",
     "polymorph-js": "^1.0.2",
     "query-string": "^6.13.1",
     "react": "^16.13.1",
     "react-chartjs-2": "^2.10.0",
     "react-dom": "^16.13.1",
     "react-tabs": "^3.1.1",
-    "react-three-fiber": "^4.2.20",
+    "react-three-fiber": "^4.2.21",
     "screenfull": "^5.0.2",
     "shutterbug": "^1.3.0",
-    "three": "^0.120.0",
+    "three": "^0.120.1",
     "threejs-meshline": "^2.0.11"
   }
 }

--- a/src/components/app.scss
+++ b/src/components/app.scss
@@ -2,8 +2,6 @@
   width: 100%;
   height: 100%;
   background: linear-gradient(28deg, #F0F0F0 0%, #C5C3C3 100%);
-  display: flex;
-  flex-direction: column;
   background-color: #c8c8c8;
   overflow: hidden;
 
@@ -14,22 +12,23 @@
 
 .mainContent {
   width: 100%;
-  flex-grow: 1000; // push bottom bar to the bottom edge
-
-  display: flex;
+  height: calc(100% - 65px);
 
   .topView, .sideContainer {
-    flex-grow: 1;
+    display: inline-block;
+    width: 50%;
     height: 100%;
+    vertical-align: top;
   }
   .sideContainer {
-    min-width: 50%;
+    //min-width: 50%;
   }
 }
 
 .bottomBar {
   width: 100%;
-  flex-grow: 1;
+  position: fixed;
+  bottom: 0;
 }
 
 .timeDisplay {

--- a/src/components/bottom-bar.scss
+++ b/src/components/bottom-bar.scss
@@ -14,6 +14,10 @@
 
   .rainDurationButtons {
     text-align: center;
+    &.disabled {
+      pointer-events: none;
+      opacity: 0.5;
+    }
     svg {
       width: 20px;
       height: 20px;

--- a/src/components/bottom-bar.test.tsx
+++ b/src/components/bottom-bar.test.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { mount } from "enzyme";
+import { BottomBar } from "./bottom-bar";
+import css from "./bottom-bar.scss";
+import { storesContext } from "../use-stores";
+import { IStores, createStores } from "../models/stores";
+
+export const StoreProvider = ({ stores, children }: { stores: IStores, children: any }) => {
+  return <storesContext.Provider value={stores}>{children}</storesContext.Provider>;
+};
+
+describe("BottomBar", () => {
+  it("renders basic widgets", () => {
+    const wrapper = mount(<BottomBar />);
+    expect(wrapper.find('[data-test="rain-intensity"]').hostNodes().length).toEqual(1);
+    expect(wrapper.find('[data-test="starting-water-level"]').hostNodes().length).toEqual(1);
+    expect(wrapper.find('[data-test="increase-rain-duration"]').hostNodes().length).toEqual(1);
+    expect(wrapper.find('[data-test="decrease-rain-duration"]').hostNodes().length).toEqual(1);
+    expect(wrapper.find('[data-test="time-slider"]').hostNodes().length).toEqual(1);
+    expect(wrapper.find('[data-test="levees-button"]').hostNodes().length).toEqual(1);
+    expect(wrapper.find('[data-test="reload-button"]').hostNodes().length).toEqual(1);
+    expect(wrapper.find('[data-test="restart-button"]').hostNodes().length).toEqual(1);
+    expect(wrapper.find('[data-test="start-stop-button"]').hostNodes().length).toEqual(1);
+
+  });
+
+  it("disabled play button when model isn't ready yet", () => {
+    const stores = createStores();
+    const wrapper = mount(<StoreProvider stores={stores}><BottomBar /></StoreProvider>);
+    expect(wrapper.find('[data-test="start-stop-button"]').at(0).prop("disabled")).toEqual(true);
+    stores.simulation.dataReady = true;
+    wrapper.update();
+    expect(wrapper.find('[data-test="start-stop-button"]').at(0).prop("disabled")).toEqual(false);
+  });
+
+  it("disables rain components when model is started", () => {
+    const stores = createStores();
+    const wrapper = mount(<StoreProvider stores={stores}><BottomBar /></StoreProvider>);
+    expect(wrapper.find('[data-test="rain-intensity"]').at(0).prop("disabled")).toEqual(false);
+    expect(wrapper.find('[data-test="starting-water-level"]').at(0).prop("disabled")).toEqual(false);
+    expect(wrapper.find('[data-test="rain-duration"]').at(0).hasClass(css.disabled)).toEqual(false);
+    stores.simulation.simulationStarted = true;
+    wrapper.update();
+    expect(wrapper.find('[data-test="rain-intensity"]').at(0).prop("disabled")).toEqual(true);
+    expect(wrapper.find('[data-test="starting-water-level"]').at(0).prop("disabled")).toEqual(true);
+    expect(wrapper.find('[data-test="rain-duration"]').at(0).hasClass(css.disabled)).toEqual(true);
+  });
+});

--- a/src/components/bottom-bar.tsx
+++ b/src/components/bottom-bar.tsx
@@ -67,6 +67,7 @@ export const BottomBar: React.FC = observer(function WrappedComponent() {
     <BottomBarContainer>
       <BottomBarWidgetGroup title="Amount of Rain" hoverable={true} className={css.amountOfRain}>
         <Slider
+          data-test="rain-intensity"
           value={simulation.rainIntensity}
           min={RainIntensity.light}
           max={config.extremeRain ? RainIntensity.extreme : RainIntensity.heavy}
@@ -80,13 +81,14 @@ export const BottomBar: React.FC = observer(function WrappedComponent() {
         <div className={css.rainDurationValue}>
           { simulation.rainDurationInDays + (simulation.rainDurationInDays === 1 ? " day" : " days") }
         </div>
-        <div className={`${css.rainDurationButtons} ${simulation.simulationStarted ? css.disabled : ""}`}>
-          <LessIcon onClick={handleDecreaseRainDuration}/>
-          <MoreIcon onClick={handleIncreaseRainDuration}/>
+        <div className={`${css.rainDurationButtons} ${simulation.simulationStarted ? css.disabled : ""}`} data-test={"rain-duration"}>
+          <LessIcon onClick={handleDecreaseRainDuration} data-test="increase-rain-duration"/>
+          <MoreIcon onClick={handleIncreaseRainDuration} data-test="decrease-rain-duration"/>
         </div>
       </BottomBarWidgetGroup>
       <BottomBarWidgetGroup title={["Starting", "Water Level"]} hoverable={true} className={css.startingWaterLevel}>
         <Slider
+          data-test="starting-water-level"
           value={simulation.initialWaterSaturation}
           min={RiverStage.low}
           max={RiverStage.high}
@@ -102,7 +104,7 @@ export const BottomBar: React.FC = observer(function WrappedComponent() {
           <div className={css.leveesCount}>{ simulation.remainingLevees }</div>
           <IconButton
             icon={<LeveeIcon />} highlightIcon={<LeveeHighlightIcon />}
-            buttonText="Levee" dataTest="levee-button" onClick={handleLeveeMode}
+            buttonText="Levee" dataTest="levees-button" onClick={handleLeveeMode}
           />
         </BottomBarWidgetGroup>
       }

--- a/src/components/bottom-bar.tsx
+++ b/src/components/bottom-bar.tsx
@@ -72,6 +72,7 @@ export const BottomBar: React.FC = observer(function WrappedComponent() {
           max={config.extremeRain ? RainIntensity.extreme : RainIntensity.heavy}
           step={null} // restrict values to marks values
           marks={config.extremeRain ? rainIntensityMarks : rainIntensityMarksWithoutExtreme}
+          disabled={simulation.simulationStarted}
           onChange={handleRainIntensityChange}
         />
       </BottomBarWidgetGroup>
@@ -79,7 +80,7 @@ export const BottomBar: React.FC = observer(function WrappedComponent() {
         <div className={css.rainDurationValue}>
           { simulation.rainDurationInDays + (simulation.rainDurationInDays === 1 ? " day" : " days") }
         </div>
-        <div className={css.rainDurationButtons}>
+        <div className={`${css.rainDurationButtons} ${simulation.simulationStarted ? css.disabled : ""}`}>
           <LessIcon onClick={handleDecreaseRainDuration}/>
           <MoreIcon onClick={handleIncreaseRainDuration}/>
         </div>
@@ -91,6 +92,7 @@ export const BottomBar: React.FC = observer(function WrappedComponent() {
           max={RiverStage.high}
           step={null} // restrict values to marks values
           marks={startingWaterLevelMarks}
+          disabled={simulation.simulationStarted}
           onChange={handleStartingWaterLevel}
         />
       </BottomBarWidgetGroup>

--- a/src/components/gauge-reading-graph.scss
+++ b/src/components/gauge-reading-graph.scss
@@ -1,6 +1,6 @@
 .graphContainer {
   padding-top: 10px;
-  flex-grow: 10;
+  flex: 10;
 }
 
 .graph {

--- a/src/components/gauge-tab.tsx
+++ b/src/components/gauge-tab.tsx
@@ -1,17 +1,23 @@
 import React from "react";
 import { CrossSectionSVGView } from "./cross-section-svg-view";
 import { GaugeReadingGraph } from "./gauge-reading-graph";
+import {observer} from "mobx-react-lite";
 import css from "./gauge-tab.scss";
+import {useStores} from "../use-stores";
 
 interface IProps {
   gauge: number;
 }
 
-export const GaugeTab: React.FC<IProps> = ({ gauge }) => {
+export const GaugeTab: React.FC<IProps> = observer(({ gauge }) => {
+  const { simulation } = useStores();
+  if (!simulation.dataReady) {
+    return null;
+  }
   return (
     <div className={css.gaugeTab}>
       <CrossSectionSVGView gauge={gauge} />
       <GaugeReadingGraph gauge={gauge} />
     </div>
   );
-};
+});

--- a/src/components/time-slider.tsx
+++ b/src/components/time-slider.tsx
@@ -76,6 +76,7 @@ export const TimeSlider: React.FC = observer(function WrappedComponent() {
     <div className={css.timeSlider}>
       <BorderLinearProgress variant="determinate" value={progress} className={css.progress} />
       <SliderWithoutRail
+        data-test="time-slider"
         value={val}
         min={0}
         max={timeMarks.length - 1}

--- a/src/components/view-3d/camera-controls.tsx
+++ b/src/components/view-3d/camera-controls.tsx
@@ -38,8 +38,8 @@ export const CameraControls = observer(function WrappedComponent() {
     zoomSpeed={0.5}
     minDistance={0.8}
     maxDistance={5}
-    // maxPolarAngle={Math.PI * 0.4}
-    // minAzimuthAngle={-Math.PI * 0.25}
-    // maxAzimuthAngle={Math.PI * 0.25}
+    maxPolarAngle={Math.PI * 0.45}
+    minAzimuthAngle={-Math.PI * 0.4}
+    maxAzimuthAngle={Math.PI * 0.4}
   />;
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -83,6 +83,8 @@ export interface ISimulationConfig {
   startingWaterLevel: "low" | "medium" | "high";
   // Initial map type.
   mapType: "street" | "topo" | "permeability";
+  // Initially selected tab.
+  activeTab: "maps" | "graph" | "gauge1" | "gauge2" | "gauge3";
 }
 
 export interface ICoords {
@@ -155,7 +157,8 @@ export const getDefaultConfig: () => IUrlConfig = () => ({
   rainIntensity: "medium",
   rainDuration: 2,
   startingWaterLevel: "medium",
-  mapType: "street"
+  mapType: "street",
+  activeTab: "gauge1"
 });
 
 const getURLParam = (name: string) => {

--- a/src/geohazard-components/geohazard-mui-theme.ts
+++ b/src/geohazard-components/geohazard-mui-theme.ts
@@ -71,7 +71,10 @@ export default createMuiTheme({
     },
     MuiSlider: {
       root: {
-        zIndex: 1
+        zIndex: 1,
+        "&$disabled": {
+          opacity: 0.5
+        }
       },
       thumb: {
         height: 20,
@@ -81,6 +84,12 @@ export default createMuiTheme({
         marginLeft: -10,
         "&:hover, &$active": {
           boxShadow: "0 0 0 4px rgba(255,255,255,0.5)"
+        },
+        "&$disabled": {
+          height: 20,
+          width: 20,
+          marginTop: -9,
+          marginLeft: -10
         }
       },
       active: {},

--- a/src/geohazard-components/geohazard-mui-theme.ts
+++ b/src/geohazard-components/geohazard-mui-theme.ts
@@ -72,6 +72,7 @@ export default createMuiTheme({
     MuiSlider: {
       root: {
         zIndex: 1,
+        padding: "13px 0 !important", // to overwrite @media (pointer: coarse) styling
         "&$disabled": {
           opacity: 0.5
         }
@@ -108,7 +109,8 @@ export default createMuiTheme({
       markLabel: {
         fontFamily: "Roboto Condensed",
         fontSize: "10px",
-        marginLeft: "1px"
+        marginLeft: "1px",
+        top: "26px !important" // to overwrite @media (pointer: coarse) styling
       }
     }
   }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,8 +3,6 @@ import ReactDOM from "react-dom";
 import { AppComponent } from "./components/app";
 import { MuiThemeProvider } from "@material-ui/core/styles";
 import geohazardTheme from "./geohazard-components/geohazard-mui-theme";
-// See: https://github.com/mobxjs/mobx-react-lite#observer-batching
-import "mobx-react-lite/batchingForReactDom";
 
 ReactDOM.render(
   <MuiThemeProvider theme={geohazardTheme}>

--- a/src/models/cell.test.ts
+++ b/src/models/cell.test.ts
@@ -12,12 +12,22 @@ describe("Cell", () => {
     });
   });
 
-  describe("elevation", () => {
-    it("returns sum baseElevation and waterDepth", () => {
-      const c = new Cell({ x: 0, y: 0, baseElevation: 1, waterDepth: 2 });
-      expect(c.elevation).toEqual(3);
+  describe("isLevee", () => {
+    it("returns true is there's any levee", () => {
+      const c = new Cell({ x: 0, y: 0 });
+      c.leveeHeight = 2;
+      expect(c.isLevee).toEqual(true);
     });
   });
+
+  describe("elevation", () => {
+    it("returns sum baseElevation, waterDepth and leeve", () => {
+      const c = new Cell({ x: 0, y: 0, baseElevation: 1, waterDepth: 2 });
+      c.leveeHeight = 3;
+      expect(c.elevation).toEqual(6);
+    });
+  });
+
 
   describe("reset", () => {
     it("resets waterDepth and flux", () => {
@@ -27,6 +37,7 @@ describe("Cell", () => {
       c.fluxT = 3;
       c.fluxB = 4;
       c.waterDepth = 5;
+      c.waterSaturation = 6;
       c.reset();
       expect(c.fluxOut).toEqual(0);
       expect(c.fluxL).toEqual(0);
@@ -34,6 +45,7 @@ describe("Cell", () => {
       expect(c.fluxT).toEqual(0);
       expect(c.fluxB).toEqual(0);
       expect(c.waterDepth).toEqual(0);
+      expect(c.waterSaturation).toEqual(0);
     });
   });
 });

--- a/src/models/cell.ts
+++ b/src/models/cell.ts
@@ -16,6 +16,7 @@ export interface ICellSnapshot {
   fluxR: number;
   fluxT: number;
   fluxB: number;
+  leveeHeight: number;
 }
 
 export class Cell {
@@ -75,7 +76,8 @@ export class Cell {
       fluxL: this.fluxL,
       fluxR: this.fluxR,
       fluxT: this.fluxT,
-      fluxB: this.fluxB
+      fluxB: this.fluxB,
+      leveeHeight: this.leveeHeight
     };
   }
 

--- a/src/models/engine/flooding-engine.ts
+++ b/src/models/engine/flooding-engine.ts
@@ -45,7 +45,6 @@ export class FloodingEngine {
   public riverStageIncreaseSpeed: number;
 
   // Outputs
-  public simulationDidStop = false;
   public waterSum = 0;
   public riverWaterSum = 0;
   public waterSaturationIncrement = 0;

--- a/src/models/flood-area-dataset.test.ts
+++ b/src/models/flood-area-dataset.test.ts
@@ -56,4 +56,21 @@ describe("FloodAreaDataset", () => {
 
     expect(dataset.points).toEqual([]);
   });
+
+  describe("getCurrentPoints", () => {
+    it("returns slice of the array based on the simulation time", () => {
+      const sim = getSimulation();
+      const dataset = new FloodAreaDataset(sim);
+      dataset.points.push({x: 1, y: 1}, {x: 2, y: 2}, {x: 3, y: 3});
+
+      sim.timeInHours = 0;
+      expect(dataset.getCurrentPoints()).toEqual([{x: 1, y: 1}]);
+
+      sim.timeInHours = 1;
+      expect(dataset.getCurrentPoints()).toEqual([{x: 1, y: 1}, {x: 2, y: 2}]);
+
+      sim.timeInHours = 2;
+      expect(dataset.getCurrentPoints()).toEqual([{x: 1, y: 1}, {x: 2, y: 2}, {x: 3, y: 3}]);
+    });
+  });
 });

--- a/src/models/gauge-reading-dataset.test.ts
+++ b/src/models/gauge-reading-dataset.test.ts
@@ -72,4 +72,24 @@ describe("GaugeReadingDataset", () => {
 
     expect(dataset.points).toEqual([ [], [] ]);
   });
+
+  describe("getCurrentPoints", () => {
+    it("returns slice of the array based on the simulation time", () => {
+      const sim = getSimulation();
+      const dataset = new GaugeReadingDataset(sim);
+      dataset.points = [[{x: 1, y: 1}, {x: 2, y: 2}, {x: 3, y: 3}], [{x: 1, y: 2}, {x: 2, y: 4}, {x: 3, y: 6}]];
+
+      sim.timeInHours = 0;
+      expect(dataset.getCurrentPoints(0)).toEqual([{x: 1, y: 1}]);
+      expect(dataset.getCurrentPoints(1)).toEqual([{x: 1, y: 2}]);
+
+      sim.timeInHours = 1;
+      expect(dataset.getCurrentPoints(0)).toEqual([{x: 1, y: 1}, {x: 2, y: 2}]);
+      expect(dataset.getCurrentPoints(1)).toEqual([{x: 1, y: 2}, {x: 2, y: 4}]);
+
+      sim.timeInHours = 2;
+      expect(dataset.getCurrentPoints(0)).toEqual([{x: 1, y: 1}, {x: 2, y: 2}, {x: 3, y: 3}]);
+      expect(dataset.getCurrentPoints(1)).toEqual([{x: 1, y: 2}, {x: 2, y: 4}, {x: 3, y: 6}]);
+    });
+  });
 });

--- a/src/models/simulation.ts
+++ b/src/models/simulation.ts
@@ -271,11 +271,13 @@ export class SimulationModel {
       this.riverCells = result.riverCells;
       this.riverBankSegments = result.riverBankSegments;
 
-      this.dataReady = true;
       this.engine = new FloodingEngine(this.cells, this.config);
 
       this.updateCellsBaseStateFlag();
       this.updateCellsSimulationStateFlag();
+      this.updateCrossSectionStates();
+
+      this.dataReady = true;
     });
   }
 

--- a/src/models/simulation.ts
+++ b/src/models/simulation.ts
@@ -356,10 +356,6 @@ export class SimulationModel {
         this.engine.update(this.config.timeStep);
       }
 
-      if (this.engine.simulationDidStop) {
-        this.simulationRunning = false;
-      }
-
       if (this.timeInHours !== oldTimeInHours) {
         this.emit("hourChange"); // used by graphs
       }

--- a/src/models/ui.test.ts
+++ b/src/models/ui.test.ts
@@ -1,0 +1,23 @@
+import { UIModel } from "./ui";
+import { getDefaultConfig } from "../config";
+
+describe("UI model", () => {
+  describe("reload", () => {
+    it("restores user settings", () => {
+      const config = getDefaultConfig();
+      const ui = new UIModel(config);
+
+      ui.tabIndex = 123;
+      ui.mainLayer = "permeability123" as "permeability"; // just to ensure we don't set the default value from config
+      ui.poiLayerEnabled = false;
+      ui.placesLayerEnabled = false;
+
+      ui.reload();
+
+      expect(ui.tabIndex).toEqual(config.tabs.indexOf(config.activeTab));
+      expect(ui.mainLayer).toEqual(config.mapType);
+      expect(ui.poiLayerEnabled).toEqual(true);
+      expect(ui.placesLayerEnabled).toEqual(true);
+    });
+  });
+});

--- a/src/models/ui.ts
+++ b/src/models/ui.ts
@@ -42,9 +42,13 @@ export class UIModel {
   }
 
   @action.bound public reload() {
+    const config = this.config;
+    this.mainLayer = config.mapType;
+    const tabIndex = config.tabs.indexOf(config.activeTab);
+    this.tabIndex = tabIndex !== -1 ? tabIndex : 0;
+
     this.interaction = null;
     this.interactionTarget = null;
-    this.mainLayer = this.config.mapType;
     this.poiLayerEnabled = true;
     this.placesLayerEnabled = true;
   }


### PR DESCRIPTION
1. The previous layout based on flex and large flex-grow values didn't work too well with ChartJS and it was causing issues in Safari. Now things should look fine both in Safari and when you resize the window (e.g. enter and exit full-screen mode).

2. The app will no longer crash when you try to open the cross-section tab too early.

3. There's a new URL param activeTab, e.g. ?activeTab=gauge2 to open the app with gauge 2 cross-section selected (Trudi requested that).

4. Rain UI widgets are disabled after the model is started.

5. Camera angles are limited.