### PR TITLE
Improve 3D rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "flooding-model",
-  "version": "0.0.1",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/view-3d/helpers.ts
+++ b/src/components/view-3d/helpers.ts
@@ -9,7 +9,11 @@ export const planeHeight = (simulation: SimulationModel) =>
   simulation.config.modelHeight * PLANE_WIDTH / simulation.config.modelWidth;
 
 // Ratio between model unit (meters) and 3D view distance unit (unitless).
-export const mToViewUnit = (simulation: SimulationModel) => PLANE_WIDTH / simulation.config.modelWidth;
+export const mToViewUnitRatio = (simulation: SimulationModel) => PLANE_WIDTH / simulation.config.modelWidth;
+
+// Ratio between model Z axis unit (meters) and 3D elevation (unitless, additionally scaled).
+export const mToViewElevationUnit = (simulation: SimulationModel, elevation: number) => 
+  elevation === 0 ? 0 : (elevation - simulation.config.minElevation) * mToViewUnitRatio(simulation) * simulation.config.view3dElevationMult;
 
 export const getTexture = (imgSrcOrCanvas: string | HTMLCanvasElement) => {
   let source;

--- a/src/components/view-3d/levees.tsx
+++ b/src/components/view-3d/levees.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
 import { observer } from "mobx-react-lite";
 import { useStores } from "../../use-stores";
-import { mToViewUnit } from "./helpers";
+import { mToViewUnitRatio, mToViewElevationUnit } from "./helpers";
 import * as THREE from "three";
 import * as meshline from "threejs-meshline";
 import { Interaction } from "../../models/ui";
@@ -66,7 +66,7 @@ export const LeveeSegment: React.FC<ILeveeSegmentProps> = ({ vertices, visible, 
 
 export const Levees: React.FC = observer(function WrappedComponent() {
   const { simulation, ui } = useStores();
-  const unitConversionFactor = mToViewUnit(simulation);
+  const unitConversionFactor = mToViewUnitRatio(simulation);
   const riverBankSegments = simulation.riverBankSegments;
   const cellSize = simulation.config.cellSize;
   const view3d = simulation.config.view3d;
@@ -80,7 +80,7 @@ export const Levees: React.FC = observer(function WrappedComponent() {
         pos.push(new THREE.Vector3(
           cell.x * cellSize * unitConversionFactor + halfCell,
           cell.y * cellSize * unitConversionFactor + halfCell,
-          (view3d ? cell.baseElevation * unitConversionFactor : 0) + Z_SHIFT
+          (view3d ? mToViewElevationUnit(simulation, cell.baseElevation) : 0) + Z_SHIFT
         ));
       }
       if (pos.length > 1) {
@@ -92,7 +92,7 @@ export const Levees: React.FC = observer(function WrappedComponent() {
       }
     }
     return result;
-  }, [cellSize, unitConversionFactor, riverBankSegments, view3d]);
+  }, [cellSize, unitConversionFactor, simulation, riverBankSegments, view3d]);
 
   const isLevee = useMemo(() => {
     // cellsBaseStateFlag flag marks that some changes have been made to cells (for performance reasons the whole cells

--- a/src/components/view-3d/marker.tsx
+++ b/src/components/view-3d/marker.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from "react";
 import { observer } from "mobx-react-lite";
-import { mToViewUnit, getTexture } from "./helpers";
+import { mToViewUnitRatio, mToViewElevationUnit, getTexture } from "./helpers";
 import { useStores } from "../../use-stores";
 import { PointerEvent } from "react-three-fiber/canvas";
 
@@ -32,10 +32,10 @@ export const Marker: React.FC<IProps> = observer(function WrappedComponent({
     return null;
   }
 
-  const ratio = mToViewUnit(simulation);
+  const ratio = mToViewUnitRatio(simulation);
   const x = position.x * ratio + (0.5 - anchorX) * width;
   const y = position.y * ratio + (0.5 - anchorY) * height;
-  const z = simulation.config.view3d ? (simulation.cellAt(position.x, position.y)?.elevation || 0) * ratio : 0;
+  const z = simulation.config.view3d ? mToViewElevationUnit(simulation, simulation.cellAt(position.x, position.y)?.elevation || 0) : 0;
 
   const texture = (hovered || active) && highlightTexture ? highlightTexture : defTexture;
 

--- a/src/components/view-3d/use-levee-interaction.tsx
+++ b/src/components/view-3d/use-levee-interaction.tsx
@@ -1,4 +1,4 @@
-import { mToViewUnit } from "./helpers";
+import { mToViewUnitRatio } from "./helpers";
 import { InteractionHandler } from "./interaction-handler";
 import { useStores } from "../../use-stores";
 import { PointerEvent } from "react-three-fiber/canvas";
@@ -12,7 +12,7 @@ export const useLeveeInteraction: () => InteractionHandler = () => {
   return {
     active: ui.interaction === Interaction.AddRemoveLevee,
     onPointerMove: (e: PointerEvent) => {
-      const ratio = mToViewUnit(simulation);
+      const ratio = mToViewUnitRatio(simulation);
       const xM = e.point.x / ratio;
       const yM = e.point.y / ratio;
       const cell = simulation.cellAt(xM, yM);

--- a/src/components/view-3d/use-show-coords-interaction.tsx
+++ b/src/components/view-3d/use-show-coords-interaction.tsx
@@ -1,4 +1,4 @@
-import { mToViewUnit } from "./helpers";
+import { mToViewUnitRatio } from "./helpers";
 import { InteractionHandler } from "./interaction-handler";
 import { useStores } from "../../use-stores";
 import { PointerEvent } from "react-three-fiber/canvas";
@@ -8,7 +8,7 @@ export const useShowCoordsInteraction: () => InteractionHandler = () => {
   return {
     active: simulation.config.showCoordsOnClick,
     onPointerUp: (e: PointerEvent) => {
-      const ratio = mToViewUnit(simulation);
+      const ratio = mToViewUnitRatio(simulation);
       const xM = e.point.x / ratio;
       const yM = e.point.y / ratio;
       const cell = simulation.cellAt(xM, yM);

--- a/src/components/view-3d/view-3d.tsx
+++ b/src/components/view-3d/view-3d.tsx
@@ -59,8 +59,8 @@ export const View3d = observer(() => {
       {
         config.view3d &&
         <>
-          <hemisphereLight args={[0xC6C2B6, 0x3A403B, 1.2]} up={DEFAULT_UP} intensity={1.0}/>
-          <pointLight position={[0.5, 0.5, 3]} intensity={0.3}/>
+          <pointLight position={[0.5, 0.5, 3]} intensity={0.5}/>
+          <ambientLight intensity={0.5} />
         </>
       }
       <Terrain interactions={terrainInteractions} textureImg={mainLayer} />

--- a/src/config.ts
+++ b/src/config.ts
@@ -50,7 +50,10 @@ export interface ISimulationConfig {
   modelTimeToHours: number;
   // Rain starts with small delay, it's sunny at the beginning of the simulation.
   rainStartDay: number;
+  // Enables 3D rendering of elevation data.
   view3d: boolean;
+  // This value can be used to make elevation more pronounced, but only during rendering.
+  view3dElevationMult: number;
   crossSections: ICrossSectionConfig[];
   // Length of the river bank segment that is used to construct levees (in meters).
   riverBankSegmentLength: number;
@@ -144,6 +147,7 @@ export const getDefaultConfig: () => IUrlConfig = () => ({
   modelTimeToHours: 0.05,
   rainStartDay: 1,
   view3d: false,
+  view3dElevationMult: 1,
   crossSections: [],
   riverBankSegmentLength: 700, // m
   leveeHeight: 4, // m

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -15,6 +15,7 @@ const presets: {[key: string]: Partial<ISimulationConfig>} = {
     maxElevation: 250, // m
     modelHeight: 8000, // m
     modelWidth: 8000, // m
+    view3dElevationMult: 3, // elevation differences are relatively small, so make them more pronounced in 3d rendering
     crossSections: [
       {
         minRiverDepth: 0.5, // m


### PR DESCRIPTION
[#177624977]

This PR adds `view3dElevationMult` so relatively flat terrain has elevation features more visible / pronounced. Also, it improves the lighting, performance of 3D rendering, and shifts the terrain down to 0, so we avoid strange rendering where the map has thick edges.

Old 3D view:
<img width="1248" alt="Screenshot 2021-04-23 at 20 56 01" src="https://user-images.githubusercontent.com/767857/115917363-6efb6f00-a476-11eb-8aa5-79c36c835414.png">

New 3D view:
<img width="1283" alt="Screenshot 2021-04-23 at 20 56 38" src="https://user-images.githubusercontent.com/767857/115917369-702c9c00-a476-11eb-8277-169a928e8e6e.png">

@knowuh, I'm going to mark you as a reviewer, as I'm assuming you might be involved in all Geo* projects after Chris left. Let me know if you're overloaded with other things.


