### PR TITLE
chore: update license text (FM-3)

### DIFF
--- a/src/geohazard-components/top-bar/copyright.tsx
+++ b/src/geohazard-components/top-bar/copyright.tsx
@@ -2,16 +2,8 @@ import * as React from "react";
 
 export const Copyright = () => (
   <p style={{ fontSize: "0.8em" }}>
-    <b>Copyright © {(new Date()).getFullYear()}</b> <a href="http://concord.org" target="_blank" rel="noreferrer">The Concord
-    Consortium
-                                                    </a>.
-    All rights reserved. The software is licensed under
-    the <a href="https://github.com/concord-consortium/flooding-model/blob/master/LICENSE"
-            target="_blank" rel="noreferrer">MIT
-        </a> license.
-    The content is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" rel="noreferrer">
-    Creative Commons Attribution 4.0 International License
-                                    </a>.
-    Please provide attribution to the Concord Consortium and the URL <a href="http://concord.org" rel="noreferrer" target="_blank">http://concord.org</a>.
+    <b>Copyright © {(new Date()).getFullYear()}</b> <a href="https://concord.org" target="_blank" rel="noreferrer">The Concord Consortium</a>.
+    All rights reserved. This resource is licensed under a <a href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank" rel="noreferrer">Creative Commons Attribution-NonCommercial 4.0 International License (CC BY-NC 4.0)</a>.
+    Please provide attribution to the Concord Consortium and the URL <a href="https://concord.org" rel="noreferrer" target="_blank">https://concord.org</a>. For full licensing details, see <a href="https://concord.org/licensing" target="_blank" rel="noreferrer">concord.org/licensing</a>.
   </p>
 );


### PR DESCRIPTION
[FM-3](https://concord-consortium.atlassian.net/browse/FM-3)

Updates the licensing information displayed in the footer of both the Share and About modals.

[FM-3]: https://concord-consortium.atlassian.net/browse/FM-3?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ